### PR TITLE
Output results to summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,3 +181,4 @@ All Contrast Security related account secrets should be configured as GitHub sec
 - severity - Allows user to report libraries with vulnerabilities above a chosen severity level. Values for level are high, medium or low. (Note: Use this input in combination with the fail input, otherwise the action will exit)
 - fail - When set to true, fails the action if CVEs have been detected that match at least the severity option specified.
 - ignoreDev - When set to true, excludes developer dependencies from the results.
+- outputSummary - Defaults to true.  When set to true, writes the output of the audit to the GitHub Actions Summary.

--- a/action.yml
+++ b/action.yml
@@ -53,5 +53,5 @@ runs:
           echo "IGNORE_DEV=true" >> $GITHUB_ENV
         fi
     - id: perform-source-composition-analysis
-      run: SEVERITY=${{ inputs.severity }} && ./contrast audit --file ${{ inputs.filePath }} --api-key ${{ inputs.apiKey }} --authorization ${{ inputs.authHeader }} --organization-id ${{ inputs.orgId }} --host ${{ inputs.apiUrl }} ${IGNORE_DEV:+"--ignore-dev"} ${FAIL:+"--fail"} ${SEVERITY:+"--severity"} ${SEVERITY:+"$SEVERITY"} --save
+      run: SEVERITY=${{ inputs.severity }} && ./contrast audit --file ${{ inputs.filePath }} --api-key ${{ inputs.apiKey }} --authorization ${{ inputs.authHeader }} --organization-id ${{ inputs.orgId }} --host ${{ inputs.apiUrl }} ${IGNORE_DEV:+"--ignore-dev"} ${FAIL:+"--fail"} ${SEVERITY:+"--severity"} ${SEVERITY:+"$SEVERITY"} --save >> $GITHUB_STEP_SUMMARY
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,10 @@ inputs:
   ignoreDev:
     description: 'When set to true, excludes developer dependencies from the results.'
     required: false
+  outputSummary:
+    description: 'Defaults to true.  When set to true, writes the output of the audit to the GitHub Actions Summary.'
+    required: false
+    default: true
 runs:
   using: "composite"
   steps:
@@ -53,5 +57,11 @@ runs:
           echo "IGNORE_DEV=true" >> $GITHUB_ENV
         fi
     - id: perform-source-composition-analysis
-      run: SEVERITY=${{ inputs.severity }} && ./contrast audit --file ${{ inputs.filePath }} --api-key ${{ inputs.apiKey }} --authorization ${{ inputs.authHeader }} --organization-id ${{ inputs.orgId }} --host ${{ inputs.apiUrl }} ${IGNORE_DEV:+"--ignore-dev"} ${FAIL:+"--fail"} ${SEVERITY:+"--severity"} ${SEVERITY:+"$SEVERITY"} --save >> $GITHUB_STEP_SUMMARY
+      run: |
+        if [ "${{inputs.output_summary}}" = true ]
+        then
+          SEVERITY=${{ inputs.severity }} && ./contrast audit --file ${{ inputs.filePath }} --api-key ${{ inputs.apiKey }} --authorization ${{ inputs.authHeader }} --organization-id ${{ inputs.orgId }} --host ${{ inputs.apiUrl }} ${IGNORE_DEV:+"--ignore-dev"} ${FAIL:+"--fail"} ${SEVERITY:+"--severity"} ${SEVERITY:+"$SEVERITY"} --save >> $GITHUB_STEP_SUMMARY
+        else
+          SEVERITY=${{ inputs.severity }} && ./contrast audit --file ${{ inputs.filePath }} --api-key ${{ inputs.apiKey }} --authorization ${{ inputs.authHeader }} --organization-id ${{ inputs.orgId }} --host ${{ inputs.apiUrl }} ${IGNORE_DEV:+"--ignore-dev"} ${FAIL:+"--fail"} ${SEVERITY:+"--severity"} ${SEVERITY:+"$SEVERITY"} --save
+        fi
       shell: bash


### PR DESCRIPTION
While trying to setup the action in other repos, I noticed that the output ended up buried.  Hard to see what the problems may be when not in a failing mode, which is our default right now.  I realized if we just output the results of `contrast audit` to the summary, it'll end up as markdown compliant output and show to users.  This gives better visibility to developers to make a decision if a finding is required to be fixed or not (plus they may not be making a change to the manifest so the relevancy of the report may not be as useful).