### PR TITLE
Set OUTPUT_SUMMARY to empty

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -161,7 +161,7 @@ runs:
         if [ "${{inputs.outputSummary}}" = true ]; then          
           echo "OUTPUT_SUMMARY=true" >> $GITHUB_ENV
         else
-          echo "OUTPUT_SUMMARY=false" >> $GITHUB_ENV
+          echo "OUTPUT_SUMMARY=" >> $GITHUB_ENV
         fi
 
         echo "args=${args[@]}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
OUTPUT_SUMMARY is currently being setto false if the customer passes false in as an input where is should actually be set to an empty value so the shell parameter expansion doesn't happen.

Heres an example of how it works

```
warren % export OUTPUT_SUMMARY=
warren% eval echo 'env var is set :' ${OUTPUT_SUMMARY:+" true "}
env var is set :
warren% export OUTPUT_SUMMARY=true
warren% eval echo 'env var is set :' ${OUTPUT_SUMMARY:+" true "}
env var is set : true
```